### PR TITLE
support unsized & unbased literal single bit constant

### DIFF
--- a/syntax/systemverilog.vim
+++ b/syntax/systemverilog.vim
@@ -59,6 +59,8 @@ syn keyword systemverilogRepeat      do foreach
 
 syn keyword systemverilogLabel       join_any join_none forkjoin
 
+syn match   systemverilogNumber      "'[01xXzZ]"
+
 " IEEE1800-2009 add
 syn keyword systemverilogStatement   checker endchecker
 syn keyword systemverilogStatement   accept_on reject_on


### PR DESCRIPTION
Support syntax highlighting for those (`'1`, `'0`, `'x`, `'z`) literals.
