### PR TITLE
Use 'shiftwidth()' instead of '&shiftwidth'

### DIFF
--- a/indent/systemverilog.vim
+++ b/indent/systemverilog.vim
@@ -29,7 +29,7 @@ function SystemVerilogIndent()
   if exists('b:systemverilog_indent_width')
     let offset = b:systemverilog_indent_width
   else
-    let offset = &sw
+    let offset = shiftwidth()
   endif
   if exists('b:systemverilog_indent_modules')
     let indent_modules = offset


### PR DESCRIPTION
Dear @Kocha,

Recently, I sent a patch to vim_dev, Vim developer mailing list.
But I was transferred to send a patch to you.

----------------------------------------------------------------------------------------------------

* Remaining &shiftwidth references in indent plugins
  * https://groups.google.com/forum/#!topic/vim_dev/BcDThxEkwNA
* GitHub issue
  * https://github.com/vim/vim/issues/1493

----------------------------------------------------------------------------------------------------

shiftwidth(), introduced in Vim 7.4.694, should be used instead of
direct reference to '&shiftwidth' option value. 'set sw=0' makes
Vim behave like 'set sw={tabstop option value}' (:help shiftwidth()).

But currently this feature does not work on your indent plugins
due to the direct reference '&shiftwidth'.

And I guess you are the maintainer of the following indent plugins:
* systemverilog.vim

I would be glad if you merge this pull request,
And then, would you like to send the latest plugins to Bram?